### PR TITLE
WIP: feat: Add support for scheduled tasks to SuiteCRM

### DIFF
--- a/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
+++ b/bitnami/suitecrm/7/debian-11/rootfs/opt/bitnami/scripts/suitecrm/postunpack.sh
@@ -51,3 +51,7 @@ if [[ -d "${SUITECRM_BASE_DIR}/public" ]]; then
 else
     ensure_web_server_app_configuration_exists "suitecrm" --type php --apache-move-htaccess "no"
 fi
+
+# Adds support for scheduled tasks
+echo "* * * * * cd /bitnami/suitecrm; php -f cron.php > /dev/null 2>&1" > /etc/cron.d/suitecrm_scheduled_tasks
+chmod +x /etc/cron.d/suitecrm_scheduled_tasks


### PR DESCRIPTION
### Description of the change

This PR enables the use of scheduled tasks in SuiteCRM.

### Benefits

SuiteCRM's scheduler will be able to run tasks at specific times, even if no one is interacting with SuiteCRM at that moment.

### Possible drawbacks

If someone has a fork of this deployment where they have added the cron entry manually, this might result in each scheduled task running twice, since we are unlikely to have used the exact same filename in cron.d.

### Applicable issues

N/A

### Additional information

This change would likely be also useful for SuiteCRM 8, which is also in this repository, however, I'm not using it so I've not tried it there.

This is currently in WIP status as I verify a few more things with it. Will comment once it's verified on our end.
